### PR TITLE
Added custom JsonException

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,8 +1,17 @@
-from jsonparser import JsonParser
+from jsonparser import JsonParser, JsonException
 
 json_parser = JsonParser()
 
 file = input("Enter a file name: ")
 with open(file) as f:
     s = f.read()
-    print(json_parser.parse_json(s))
+
+    try:
+        result = json_parser.parse_json(s)
+    except JsonException as e:
+        import sys
+        print('The program failed with an error.')
+        print(f'[ERROR] - {e}', file=sys.stderr)
+        sys.exit(1)
+
+    print(result)

--- a/pyparse.py
+++ b/pyparse.py
@@ -1,4 +1,4 @@
-from jsonparser import JsonParser
+from jsonparser import JsonParser, JsonException
 import argparse
 
 parser = argparse.ArgumentParser(description='Json Parser')
@@ -10,4 +10,14 @@ json_parser = JsonParser()
 file = args.file
 with open(file) as f:
     s = f.read()
-    print(json_parser.parse_json(s))
+
+    try:
+        result = json_parser.parse_json(s)
+    except JsonException as e:
+        import sys
+        print("The program failed with an error.")
+        print(f"[ERROR] - {e}", file=sys.stderr)
+        sys.exit(1)
+
+    print(result)
+

--- a/testing.py
+++ b/testing.py
@@ -1,4 +1,4 @@
-from jsonparser import JsonParser
+from jsonparser import JsonParser, JsonException
 parser = JsonParser()
 print("Testing against test suite from http://www.json.org/JSON_checker/\n")
 # invalid json tests
@@ -14,7 +14,7 @@ for n in range(1, 33):
             result = parser.parse_json(s)
             print(f"Test {n} FAILED: Did not recognise invalid json, parsed test file content as: {result}")
 
-        except Exception as e:
+        except JsonException as e:
             print(f"Test {n} PASSED: Recognised invalid json, exception: {e}")
             tests_passed += 1
 
@@ -35,7 +35,7 @@ for n in range(1, 4):
             print(f"Test {n} PASSED: Parsed valid json, parsed test file content as: {result}")
             tests_passed += 1
 
-        except Exception as e:
+        except JsonException as e:
             print(f"Test {n} FAILED: Failed to parse valid json, exception: {e}")
 
 print(f"\nPASSED {tests_passed}/3 TESTS")


### PR DESCRIPTION
...and fixed a few places that relied on other exception types for correct behaviour

I've made it so all errors thrown by the library are of its own error type, `JsonException`. A couple of functions - e.g. `parse_number` - can throw `ValueError` or `IndexError`, so I catch these and rethrow as `JsonException`. This is to help separate errors that are the library's responsibility from any other type of error.